### PR TITLE
Removed GLOB_ONLYDIR to correctly pick up custom module's PHP files

### DIFF
--- a/packages/divi-scripts/template/includes/loader.php
+++ b/packages/divi-scripts/template/includes/loader.php
@@ -4,7 +4,7 @@ if ( ! class_exists( 'ET_Builder_Element' ) ) {
 	return;
 }
 
-$module_files = glob( __DIR__ . '/modules/*/*.php', GLOB_ONLYDIR );
+$module_files = glob( __DIR__ . '/modules/*/*.php' );
 
 // Load custom Divi Builder modules
 foreach ( (array) $module_files as $module_file ) {


### PR DESCRIPTION
I created divi extension plugin (downloadable at
https://www.dropbox.com/s/8sx81qgc8jo3p8y/divi-more-modules.zip?dl=0) using `create-divi-extension` when fixing https://github.com/elegantthemes/Divi/issues/6439. However, I noticed that the template files aren't loaded because `glob()` uses `GLOB_ONLYDIR`which makes `glob()` matches to directory only.

Removing this flag fixes the issue: the plugin correctly picks up the module's PHP file now.