### PR TITLE
Add in support for module credits to Divi extension template

### DIFF
--- a/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.php
+++ b/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.php
@@ -5,6 +5,12 @@ class __PREFIX_HelloWorld extends ET_Builder_Module {
 	public $slug       = '__prefix_hello_world';
 	public $vb_support = 'on';
 
+	protected $module_credits = array(
+		'module_uri' => '<URI>',
+		'author'     => '<AUTHOR>',
+		'author_uri' => '<AUTHOR_URI>',
+	);
+
 	public function init() {
 		$this->name = esc_html__( 'Hello World', '<GETTEXT_DOMAIN>' );
 	}


### PR DESCRIPTION
This PR adds `module_credits` array field to the `HelloWorld` template class.
This field is used to display Module and module developer credits within the VB settings modal window.