### PR TITLE
Load modules php files with same name as module dir

### DIFF
--- a/packages/divi-scripts/template/includes/loader.php
+++ b/packages/divi-scripts/template/includes/loader.php
@@ -8,7 +8,7 @@ $module_files = glob( __DIR__ . '/modules/*/*.php' );
 
 // Load custom Divi Builder modules
 foreach ( (array) $module_files as $module_file ) {
-	if ( $module_file ) {
+	if ( $module_file && preg_match( "/\/modules\/\b([^\/]+)\/\\1\.php$/", $module_file ) ) {
 		require_once $module_file;
 	}
 }


### PR DESCRIPTION
### Description
Currently the `loader.php` loads all `.php` files from module directory, but it should load only the module class `.php` file, which by convention has same name as the module directory name.

### Fixes https://github.com/elegantthemes/Divi/issues/7391
