### PR TITLE
Correct class format

### DIFF
--- a/packages/divi-scripts/template/includes/modules/HelloWorld/style.css
+++ b/packages/divi-scripts/template/includes/modules/HelloWorld/style.css
@@ -1,3 +1,3 @@
-.__prefix-hello-world {
+.__prefix_hello_world {
 
 }


### PR DESCRIPTION
![2018-04-22_140051](https://user-images.githubusercontent.com/11320080/39094286-d6a92bbc-4635-11e8-81db-bfb2425a4ed8.jpg)
Default format (with dashes) is not aligned with the actual class name.