### PR TITLE
202-patch-webpack-dev-server

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,11 +6,11 @@
   "changelog": {
     "repo": "elegantthemes/create-divi-extension",
     "labels": {
-      "tag: new feature": ":rocket: New Feature",
+      "tag: FEATURE": ":rocket: New Feature",
       "tag: breaking change": ":boom: Breaking Change",
-      "tag: bug fix": ":bug: Bug Fix",
-      "tag: enhancement": ":nail_care: Enhancement",
-      "tag: documentation": ":memo: Documentation",
+      "tag: BUG": ":bug: Bug Fix",
+      "tag: IMPROVEMENT": ":nail_care: Improvement",
+      "tag: DOCUMENTATION": ":memo: Documentation",
       "tag: internal": ":house: Internal"
     },
     "cacheDir": ".changelog"

--- a/packages/divi-scripts/bin/divi-scripts.js
+++ b/packages/divi-scripts/bin/divi-scripts.js
@@ -26,13 +26,14 @@ const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
 const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
 
 (function maybeMonkeyPatchDevServer() {
+  const path = require('path');
   const client = path.join(
     __dirname,
     'node_modules/webpack-dev-server/client/index.js'
   );
   const code = fs.readFileSync(client, 'utf-8');
 
-  if (code.includes('self.location.protocol;')) {
+  if (!code.includes('window.top.location.protocol')) {
     const new_code = code.replace(
       'self.location.protocol;',
       'window.top ? window.top.location.protocol : self.location.protocol;'

--- a/packages/divi-scripts/bin/divi-scripts.js
+++ b/packages/divi-scripts/bin/divi-scripts.js
@@ -25,6 +25,23 @@ const scriptIndex = args.findIndex(
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
 const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
 
+(function maybeMonkeyPatchDevServer() {
+  const client = path.join(
+    __dirname,
+    'node_modules/webpack-dev-server/client/index.js'
+  );
+  const code = fs.readFileSync(client, 'utf-8');
+
+  if (code.includes('self.location.protocol;')) {
+    const new_code = code.replace(
+      'self.location.protocol;',
+      'window.top ? window.top.location.protocol : self.location.protocol;'
+    );
+
+    fs.writeFileSync(client, new_code);
+  }
+})();
+
 switch (script) {
   case 'build':
   case 'eject':

--- a/packages/divi-scripts/bin/divi-scripts.js
+++ b/packages/divi-scripts/bin/divi-scripts.js
@@ -25,24 +25,6 @@ const scriptIndex = args.findIndex(
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
 const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
 
-(function maybeMonkeyPatchDevServer() {
-  const path = require('path');
-  const client = path.join(
-    __dirname,
-    'node_modules/webpack-dev-server/client/index.js'
-  );
-  const code = fs.readFileSync(client, 'utf-8');
-
-  if (!code.includes('window.top.location.protocol')) {
-    const new_code = code.replace(
-      'self.location.protocol;',
-      'window.top ? window.top.location.protocol : self.location.protocol;'
-    );
-
-    fs.writeFileSync(client, new_code);
-  }
-})();
-
 switch (script) {
   case 'build':
   case 'eject':

--- a/packages/divi-scripts/scripts/start.js
+++ b/packages/divi-scripts/scripts/start.js
@@ -32,7 +32,6 @@ if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
 
 const chalk = require('chalk');
 const webpack = require('webpack');
-const WebpackDevServer = require('webpack-dev-server');
 const clearConsole = require('divi-dev-utils/clearConsole');
 const checkRequiredFiles = require('divi-dev-utils/checkRequiredFiles');
 const {
@@ -47,6 +46,25 @@ const config = require('../config/webpack.config.dev');
 const createDevServerConfig = require('../config/webpackDevServer.config');
 const wp_config = require('divi-dev-utils/WPConfig');
 
+(function maybeMonkeyPatchDevServer() {
+  const path = require('path');
+  const client = path.join(
+    paths.appNodeModules,
+    'webpack-dev-server/client/index.js'
+  );
+  const code = fs.readFileSync(client, 'utf-8');
+
+  if (!code.includes('window.top.location.protocol')) {
+    const new_code = code.replace(
+      'self.location.protocol;',
+      'window.top ? window.top.location.protocol : self.location.protocol;'
+    );
+
+    fs.writeFileSync(client, new_code);
+  }
+})();
+
+const WebpackDevServer = require('webpack-dev-server');
 const isInteractive = process.stdout.isTTY;
 
 // Warn and crash if required files are missing


### PR DESCRIPTION
### Summary
CDE:: Add patch for webpack devserver to properly support Divi 3.18+ without breaking backwards compatibility. [pr]


Fixes elegantthemes/create-divi-extension#202.