### PR TITLE
DA2 :: Allow 3rd party code to import Divi components.

### DIFF
--- a/packages/divi-scripts/config/webpack.config.dev.js
+++ b/packages/divi-scripts/config/webpack.config.dev.js
@@ -118,6 +118,8 @@ module.exports = {
     chunkFilename: 'static/js/[name].chunk.js',
     // This is the URL that app is served from. We use "/" in development.
     publicPath: publicPath,
+    // Import @divi packages from window
+    libraryTarget: 'window',
     // Point sourcemap entries to original disk location (format as URL on Windows)
     devtoolModuleFilenameTemplate: info =>
       path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
@@ -161,12 +163,27 @@ module.exports = {
       new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
     ],
   },
-  externals: {
-    jquery: 'jQuery',
-    underscore: '_',
-    react: 'React',
-    'react-dom': 'ReactDOM',
-  },
+  externals: [
+    {
+      jquery: 'jQuery',
+      underscore: '_',
+      react: 'React',
+      'react-dom': 'ReactDOM',
+    },
+    // Resolve nested @divi imports like
+    // @divi/api
+    // @divi/components
+    // @divi/controls/textarea
+    (context, request, callback) => {
+      if (/^@divi\//.test(request)){
+        const path = request.split('/').slice(1);
+        callback(null, { window: ['ET_Builder_Exports', 'bundle', ...path] });
+      } else {
+        // Not a @divi request.
+        callback();
+      }
+    }
+  ],
   module: {
     strictExportPresence: true,
     rules: [

--- a/packages/divi-scripts/config/webpack.config.prod.js
+++ b/packages/divi-scripts/config/webpack.config.prod.js
@@ -120,6 +120,8 @@ module.exports = {
     chunkFilename: 'scripts/[name].chunk.js',
     // We inferred the "public path" (such as / or /my-project) from homepage.
     publicPath: publicPath,
+    // Import @divi packages from window
+    libraryTarget: 'window',
     // Point sourcemap entries to original disk location (format as URL on Windows)
     devtoolModuleFilenameTemplate: info =>
       path
@@ -165,12 +167,27 @@ module.exports = {
       new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
     ],
   },
-  externals: {
-    jquery: 'jQuery',
-    underscore: '_',
-    react: 'React',
-    'react-dom': 'ReactDOM',
-  },
+  externals: [
+    {
+      jquery: 'jQuery',
+      underscore: '_',
+      react: 'React',
+      'react-dom': 'ReactDOM',
+    },
+    // Resolve nested @divi imports like
+    // @divi/api
+    // @divi/components
+    // @divi/controls/textarea
+    (context, request, callback) => {
+      if (/^@divi\//.test(request)){
+        const path = request.split('/').slice(1);
+        callback(null, { window: ['ET_Builder_Exports', 'bundle', ...path] });
+      } else {
+        // Not a @divi request.
+        callback();
+      }
+    }
+  ],
   module: {
     strictExportPresence: true,
     rules: [

--- a/packages/divi-scripts/template/includes/loader.js
+++ b/packages/divi-scripts/template/includes/loader.js
@@ -1,9 +1,7 @@
 // External Dependencies
-import $ from 'jquery';
+import API from '@divi/API';
 
 // Internal Dependencies
 import modules from './modules';
 
-$(window).on('et_builder_api_ready', (event, API) => {
-  API.registerModules(modules);
-});
+API.registerModules(modules);


### PR DESCRIPTION
This PR allows us to expose components via webpack's library export.

So far, only the `API` object has been included in the library and
it can be used like this:

```JS
import API from '@divi/API';
API.registerModules(modules);
```

As opposed as the old method which required 'jQuery' and a window event:

```JS
import $ from 'jquery';
$(window).on('et_builder_api_ready', (event, API) => {
  API.registerModules(modules);
});
```

PR is backward compatible so the above code still works without
changes.

Additional components can be very easily exported in `app.jsx`

```JS
const components = {
  ETBuilderPreloader,
  controls: {
    ETBuilderControlInput,
  },
};
```

And imported in 3P code:

```JS
// 3P code willing to include our components
import { ETBuilderControlInput } from '@divi/components/controls';
```

The following changes were required:
1. `ETBuilderAPI` is instantiated upon exporting rather than when
builder initializes.
2. Extension bundles are enqueued after builder bundle (so the
exports are available to them).
3. Webpack config changes in both builder and `divi-create-extension`

Fixes https://github.com/elegantthemes/divi/issues/14636