### PR TITLE
yarn start not working on windows.

### DIFF
--- a/packages/divi-dev-utils/WPConfig.js
+++ b/packages/divi-dev-utils/WPConfig.js
@@ -59,7 +59,7 @@ class WPConfig {
 
     if ('not_found' === current_value) {
       // Add new definition
-      const regex = /(\n)(?=\/\* That's all, stop editing! Happy blogging\. \*\/)/;
+      const regex = /(\r?\n)(?=\/\* That's all, stop editing! Happy \w+\. \*\/)/;
 
       this.config = this.config.replace(
         regex,


### PR DESCRIPTION
This is due to the regexp not accounting for windows line endings
causing extension debug mode to never be set.

Also made the regex less specific in case of more changes like
WordPress/WordPress@363cfc4

Fixes https://github.com/elegantthemes/create-divi-extension/issues/249