### PR TITLE
Introduces backend bundle and adjust template for custom fields support

### DIFF
--- a/packages/divi-scripts/config/webpack.config.dev.js
+++ b/packages/divi-scripts/config/webpack.config.dev.js
@@ -12,6 +12,7 @@
 const autoprefixer = require('autoprefixer');
 const path = require('path');
 const webpack = require('webpack');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const InterpolateHtmlPlugin = require('divi-dev-utils/InterpolateHtmlPlugin');
@@ -46,6 +47,10 @@ const postCSSLoaderOptions = {
     }),
   ],
 };
+
+// Initiate ExtractTextPlugin instance for backend styles.
+const cssBackendFilename = 'styles/backend-style.css';
+const extractTextPluginBackend = new ExtractTextPlugin(cssBackendFilename);
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -332,18 +337,26 @@ module.exports = {
               },
             ],
           },
+          // Adds support for backend CSS such as custom fields and group it up as
+          // backend-style CSS.
           {
             test: /\.(s?css|sass)$/,
             exclude: [/modules/],
-            use: [
-              require.resolve('style-loader'),
-              {
-                loader: require.resolve('css-loader'),
-              },
-              {
-                loader: require.resolve('sass-loader'),
-              },
-            ],
+            use: extractTextPluginBackend.extract(
+              Object.assign({
+                fallback: {
+                  loader: require.resolve('style-loader'),
+                },
+                use: [
+                  {
+                    loader: require.resolve('css-loader'),
+                  },
+                  {
+                    loader: require.resolve('sass-loader'),
+                  },
+                ],
+              })
+            ),
           },
           // The GraphQL loader preprocesses GraphQL queries in .graphql files.
           {
@@ -378,6 +391,8 @@ module.exports = {
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'development') { ... }. See `./env.js`.
     new webpack.DefinePlugin(env.stringified),
+    // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
+    extractTextPluginBackend,
     // This is necessary to emit hot updates (currently CSS only):
     new webpack.HotModuleReplacementPlugin(),
     // Watcher doesn't work well if you mistype casing in a path so we use

--- a/packages/divi-scripts/config/webpack.config.dev.js
+++ b/packages/divi-scripts/config/webpack.config.dev.js
@@ -111,6 +111,14 @@ module.exports = {
         `!${paths.appScripts}/**/*.min.js`,
       ]),
     ],
+    backend: [
+      // Include all css files found in the 'includes/fields' directory.
+      ...glob.sync([
+        `${paths.appSrc}/fields/**/*.css`,
+        `${paths.appSrc}/fields/**/*.scss`,
+        `${paths.appSrc}/fields/**/*.sass`,
+      ]),
+    ],
   },
   output: {
     // Add /* filename */ comments to generated require()s in the output.
@@ -286,7 +294,7 @@ module.exports = {
           // By default we support CSS Modules with the extension .module.css
           {
             test: /\.(s?css|sass)$/,
-            exclude: /\.module\.css$/,
+            exclude: [/\.module\.css$/, /fields/],
             use: [
               require.resolve('style-loader'),
               {
@@ -321,6 +329,19 @@ module.exports = {
               {
                 loader: require.resolve('postcss-loader'),
                 options: postCSSLoaderOptions,
+              },
+            ],
+          },
+          {
+            test: /\.(s?css|sass)$/,
+            exclude: [/modules/],
+            use: [
+              require.resolve('style-loader'),
+              {
+                loader: require.resolve('css-loader'),
+              },
+              {
+                loader: require.resolve('sass-loader'),
               },
             ],
           },

--- a/packages/divi-scripts/config/webpack.config.prod.js
+++ b/packages/divi-scripts/config/webpack.config.prod.js
@@ -124,14 +124,6 @@ module.exports = {
         `!${paths.appScripts}/**/*.min.js`,
       ]),
     ],
-    backend: [
-      // Include all css files found in the 'includes/fields' directory.
-      ...glob.sync([
-        `${paths.appSrc}/fields/**/*.css`,
-        `${paths.appSrc}/fields/**/*.scss`,
-        `${paths.appSrc}/fields/**/*.sass`,
-      ]),
-    ],
   },
   output: {
     // The build folder.
@@ -384,8 +376,8 @@ module.exports = {
             ),
             // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
           },
-          // Adds support for non frontend CSS such as custom fields and group it up
-          // as builder-style CSS.
+          // Adds support for backend CSS such as custom fields and group it up as
+          // backend-style CSS.
           {
             test: /\.(s?css|sass)$/,
             exclude: [/modules/],
@@ -403,6 +395,12 @@ module.exports = {
                       loader: require.resolve('css-loader'),
                       options: {
                         minimize: true,
+                        sourceMap: shouldUseSourceMap,
+                      },
+                    },
+                    {
+                      loader: require.resolve('sass-loader'),
+                      options: {
                         sourceMap: shouldUseSourceMap,
                       },
                     },

--- a/packages/divi-scripts/template/README.md
+++ b/packages/divi-scripts/template/README.md
@@ -99,6 +99,8 @@ In the project directory, you can run:
 
 Builds the extension in the development mode. Open your WordPress site to view it in the browser. The page will reload if you make edits to JavaScript files. You will also see any lint errors in the console.
 
+Note that `yarn start` will enable debug mode as well. However, you may encounter an issue where it doesn't work that way and causes your custom module not loaded properly. To fix it, you can enable it manually by adding `define( 'PREFIX_DEBUG', true );` on your `wp-config.php` file. Just replace `PREFIX` with your extension prefix.
+
 ### `yarn build`
 
 Builds the extension for production to the `build` folder. It correctly optimizes the build for the best performance.

--- a/packages/divi-scripts/template/includes/fields/Input/Input.jsx
+++ b/packages/divi-scripts/template/includes/fields/Input/Input.jsx
@@ -1,0 +1,40 @@
+// External Dependencies
+import React, { Component } from 'react';
+
+// Internal Dependencies
+import './style.css';
+
+class Input extends Component {
+
+  static slug = '__prefix_input';
+
+  constructor(props) {
+    super(props);
+    this._onChange = this._onChange.bind(this);
+  }
+
+  /**
+   * Handle input value change.
+   *
+   * @param {object} event
+   */
+  _onChange(event) {
+    this.props._onChange(this.props.name, event.target.value);
+  }
+
+  render() {
+    return(
+      <input
+        id={`__prefix-input-${this.props.name}`}
+        name={this.props.name}
+        value={this.props.value}
+        type='text'
+        className='__prefix-input'
+        onChange={this._onChange}
+        placeholder='Your text here ...'
+      />
+    );
+  }
+}
+
+export default Input;

--- a/packages/divi-scripts/template/includes/fields/Input/Input.jsx
+++ b/packages/divi-scripts/template/includes/fields/Input/Input.jsx
@@ -10,7 +10,6 @@ class Input extends Component {
 
   constructor(props) {
     super(props);
-    this._onChange = this._onChange.bind(this);
   }
 
   /**
@@ -18,7 +17,7 @@ class Input extends Component {
    *
    * @param {object} event
    */
-  _onChange(event) {
+  _onChange = (event) => {
     this.props._onChange(this.props.name, event.target.value);
   }
 

--- a/packages/divi-scripts/template/includes/fields/Input/style.css
+++ b/packages/divi-scripts/template/includes/fields/Input/style.css
@@ -1,0 +1,22 @@
+input.__prefix-input {
+  width: 100%;
+  height: 30px;
+  padding: 7px 10px;
+  border-radius: 3px;
+  border-color: rgba(125, 59, 207, 0.1);
+  background-color: rgba(125, 59, 207, 0.1);
+  color: #4c5866;
+  font-size: 13px;
+  font-family: Open Sans,Helvetica,Roboto,Arial,sans-serif;
+  font-weight: 600;
+  text-transform: none;
+  line-height: normal;
+  letter-spacing: normal;
+  box-shadow: none;
+  box-sizing: border-box;
+  transition: background .2s ease;
+}
+
+input.__prefix-input:focus {
+  border-color: rgba(125, 59, 207, 1);
+}

--- a/packages/divi-scripts/template/includes/fields/index.js
+++ b/packages/divi-scripts/template/includes/fields/index.js
@@ -1,0 +1,3 @@
+import Input from './Input/Input';
+
+export default [Input];

--- a/packages/divi-scripts/template/includes/loader.js
+++ b/packages/divi-scripts/template/includes/loader.js
@@ -3,7 +3,9 @@ import $ from 'jquery';
 
 // Internal Dependencies
 import modules from './modules';
+import fields from './fields';
 
 $(window).on('et_builder_api_ready', (event, API) => {
   API.registerModules(modules);
+  API.registerModalFields(fields);
 });

--- a/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.jsx
+++ b/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.jsx
@@ -13,9 +13,12 @@ class HelloWorld extends Component {
     const Content = this.props.content;
 
     return (
-      <h1>
-        <Content/>
-      </h1>
+      <div class="__prefix-hello-world">
+        <h1>
+          <Content/>
+        </h1>
+        <p>{this.props.field}</p>
+      </div>
     );
   }
 }

--- a/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.php
+++ b/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.php
@@ -24,11 +24,25 @@ class __PREFIX_HelloWorld extends ET_Builder_Module {
 				'description'     => esc_html__( 'Content entered here will appear inside the module.', '<GETTEXT_DOMAIN>' ),
 				'toggle_slug'     => 'main_content',
 			),
+			'field'   => array(
+				'label'           => esc_html__( 'Custom Field Example', '<GETTEXT_DOMAIN>' ),
+				'type'            => '__prefix_input',
+				'option_category' => 'basic_option',
+				'description'     => esc_html__( 'Text entered here will appear inside the module.', '<GETTEXT_DOMAIN>' ),
+				'toggle_slug'     => 'main_content',
+			),
 		);
 	}
 
 	public function render( $attrs, $content = null, $render_slug ) {
-		return sprintf( '<h1>%1$s</h1>', $this->props['content'] );
+		return sprintf(
+			'<div class="__prefix-hello-world">
+				<h1>%1$s</h1>
+				<p>%2$s</p>
+			</div>',
+			$this->props['content'],
+			$this->props['field']
+		);
 	}
 }
 


### PR DESCRIPTION
This PR is part of https://github.com/elegantthemes/Divi/issues/19247

1. Introduces Backend CSS file on both of dev and production Webpack config.

So, we have 2 CSS files now.
- Frontend -> For all frontend (modules) styles
- Backend -> For custom fields styles and can be improved in the future

2. Introduces custom fields and adjust the extension template to include custom field example.

So, when user creates a Divi extension with `create-divi-extension`, it will be included with Hello World module and Input custom field as example.

![Custom Fields Example](https://user-images.githubusercontent.com/9313128/83635511-8ddae380-a5ce-11ea-97f3-aab9f4b48e66.gif)

@lots0logs @fikrirasyid I'm open for feedback and correct me if I got it wrong.