### PR TITLE
Uses builder default style for custom field input demo instead of custom style

### DIFF
--- a/packages/divi-scripts/template/includes/fields/Input/Input.jsx
+++ b/packages/divi-scripts/template/includes/fields/Input/Input.jsx
@@ -8,10 +8,6 @@ class Input extends Component {
 
   static slug = '__prefix_input';
 
-  constructor(props) {
-    super(props);
-  }
-
   /**
    * Handle input value change.
    *

--- a/packages/divi-scripts/template/includes/fields/Input/style.css
+++ b/packages/divi-scripts/template/includes/fields/Input/style.css
@@ -1,22 +1,42 @@
 input.__prefix-input {
-  width: 100%;
-  height: 30px;
-  padding: 7px 10px;
+  background: #f1f5f9;
+  max-height: 30px;
+  border: 0;
   border-radius: 3px;
-  border-color: rgba(125, 59, 207, 0.1);
-  background-color: rgba(125, 59, 207, 0.1);
-  color: #4c5866;
-  font-size: 13px;
-  font-family: Open Sans,Helvetica,Roboto,Arial,sans-serif;
-  font-weight: 600;
-  text-transform: none;
-  line-height: normal;
-  letter-spacing: normal;
-  box-shadow: none;
+  padding: 7px 10px;
   box-sizing: border-box;
-  transition: background .2s ease;
+  transition: background 200ms ease;
+  color: #4C5866;
+  font-family: 'Open Sans', Helvetica, Roboto, Arial, sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: normal;
+  display: block;
+  width: 100%;
 }
 
 input.__prefix-input:focus {
-  border-color: rgba(125, 59, 207, 1);
+  background: #e6ecf2;
+}
+
+input.__prefix-input::-webkit-input-placeholder {
+  color: #98a7b8;
+}
+
+input.__prefix-input:-moz-placeholder {
+  color: #98a7b8;
+}
+
+input.__prefix-input::-moz-placeholder {
+  color: #98a7b8;
+}
+
+input.__prefix-input:-ms-input-placeholder {
+  color: #98a7b8;
+}
+
+input.__prefix-input[readonly] {
+  background: #ffffff !important;
+  border: 1px solid #eaedf0 !important;
+  cursor: not-allowed;
 }

--- a/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.jsx
+++ b/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.jsx
@@ -13,7 +13,7 @@ class HelloWorld extends Component {
     const Content = this.props.content;
 
     return (
-      <div class="__prefix-hello-world">
+      <div className="__prefix-hello-world">
         <h1>
           <Content/>
         </h1>

--- a/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.jsx
+++ b/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.jsx
@@ -13,12 +13,9 @@ class HelloWorld extends Component {
     const Content = this.props.content;
 
     return (
-      <div className="__prefix-hello-world">
-        <h1>
-          <Content/>
-        </h1>
-        <p>{this.props.field}</p>
-      </div>
+      <h1>
+        <Content/>
+      </h1>
     );
   }
 }

--- a/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.php
+++ b/packages/divi-scripts/template/includes/modules/HelloWorld/HelloWorld.php
@@ -24,25 +24,11 @@ class __PREFIX_HelloWorld extends ET_Builder_Module {
 				'description'     => esc_html__( 'Content entered here will appear inside the module.', '<GETTEXT_DOMAIN>' ),
 				'toggle_slug'     => 'main_content',
 			),
-			'field'   => array(
-				'label'           => esc_html__( 'Custom Field Example', '<GETTEXT_DOMAIN>' ),
-				'type'            => '__prefix_input',
-				'option_category' => 'basic_option',
-				'description'     => esc_html__( 'Text entered here will appear inside the module.', '<GETTEXT_DOMAIN>' ),
-				'toggle_slug'     => 'main_content',
-			),
 		);
 	}
 
 	public function render( $attrs, $content = null, $render_slug ) {
-		return sprintf(
-			'<div class="__prefix-hello-world">
-				<h1>%1$s</h1>
-				<p>%2$s</p>
-			</div>',
-			$this->props['content'],
-			$this->props['field']
-		);
+		return sprintf( '<h1>%1$s</h1>', $this->props['content'] );
 	}
 }
 


### PR DESCRIPTION
Fixes elegantthemes/Divi#20530

Based on the feedback, we need to use default builder field style instead of the custom style. It's better for the customer for the experience to be cohesive.

This PR also fix the warning about unused `construct` method on input component and `class` property warning on Hello World module component.

![3rd Party Support - Custom Field - Default](https://user-images.githubusercontent.com/9313128/86318561-7db13500-bc5c-11ea-8f95-af88d9527434.gif)
