### PR TITLE
Fix (3rd Party Extension) :: Remove unused backend config on dev

### DIFF
--- a/packages/divi-scripts/config/webpack.config.dev.js
+++ b/packages/divi-scripts/config/webpack.config.dev.js
@@ -116,14 +116,6 @@ module.exports = {
         `!${paths.appScripts}/**/*.min.js`,
       ]),
     ],
-    backend: [
-      // Include all css files found in the 'includes/fields' directory.
-      ...glob.sync([
-        `${paths.appSrc}/fields/**/*.css`,
-        `${paths.appSrc}/fields/**/*.scss`,
-        `${paths.appSrc}/fields/**/*.sass`,
-      ]),
-    ],
   },
   output: {
     // Add /* filename */ comments to generated require()s in the output.


### PR DESCRIPTION
Additional update of elegantthemes/Divi#20530

This PR removes unused backend bundle entry on dev config. It's supposed to be removed long time ago when we introduced custom fields support. But, I think I forgot to remove it from dev config because it's no longer exist on the build/production config.