### PR TITLE
Fix #411

### DIFF
--- a/packages/divi-scripts/config/webpack.config.dev.js
+++ b/packages/divi-scripts/config/webpack.config.dev.js
@@ -291,7 +291,7 @@ module.exports = {
           // By default we support CSS Modules with the extension .module.css
           {
             test: /\.(s?css|sass)$/,
-            exclude: [/\.module\.css$/, /fields/],
+            exclude: [/\.module\.css$/, /includes\/fields/],
             use: [
               require.resolve('style-loader'),
               {

--- a/packages/divi-scripts/config/webpack.config.prod.js
+++ b/packages/divi-scripts/config/webpack.config.prod.js
@@ -305,7 +305,7 @@ module.exports = {
           // By default we support CSS Modules with the extension .module.css
           {
             test: /\.(s?css|sass)$/,
-            exclude: [/\.module\.css$/, /fields/],
+            exclude: [/\.module\.css$/, /includes\/fields/],
             use: extractTextPluginFrontend.extract(
               Object.assign(
                 {


### PR DESCRIPTION
`yarn build` fails if the project being developed has the word "fields" in its absolute path. The issue stems from this webpack configuration rule (the `exclude` part specifically):

```
{
    test: /\.(s?css|sass)$/,
    exclude: [/\.module\.css$/, /fields/],
    use: extractTextPluginFrontend.extract(
    // ...
```

The fix is by making this part of the configuration more specific.