### PR TITLE
Add more generated (and minified) files to gitignore

### DIFF
--- a/packages/divi-scripts/template/gitignore
+++ b/packages/divi-scripts/template/gitignore
@@ -8,7 +8,12 @@
 
 # production
 /scripts/bundle.min.js
+/scripts/builder-bundle.min.js
+/scripts/frontend-bundle.min.js
 /styles/bundle.min.css
+/styles/backend-style.min.css
+/styles/style-dbp.min.css
+/styles/style.min.css
 asset-manifest.json
 *.map
 


### PR DESCRIPTION
### Summary
Add more generated (and minified) files to gitignore.

Fixes: https://github.com/elegantthemes/create-divi-extension/issues/424

### Caused By
https://github.com/elegantthemes/create-divi-extension/issues/424

### Changelog copy
Add more generated (and minified) files to gitignore.

### Affected Areas
* gitignore
