### PR TITLE
README :: Updates README page to include fields directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ It will create a directory called `my-extension`. Inside that directory, it will
 ```
 my-extension
 ├── includes
+|   ├── fields
+│   │   └── Input
+│   │       ├── Input.jsx
+│   │       └── style.css
 │   ├── modules
 │   │   └── HelloWorld
 │   │       ├── HelloWorld.jsx


### PR DESCRIPTION
The `fields` directory is missing from the dir structures described on README page.