### PR TITLE
Package :: Update grunt-wp-i18n dependency to fix incompatible grunt and node version

### DIFF
--- a/packages/divi-scripts/package.json
+++ b/packages/divi-scripts/package.json
@@ -49,7 +49,7 @@
     "grunt": "1.0.2",
     "grunt-contrib-compress": "1.6.0",
     "grunt-po2mo": "elegantthemes/grunt-po2mo#master",
-    "grunt-wp-i18n": "1.0.2",
+    "grunt-wp-i18n": "ayubadiputra/grunt-wp-i18n#testing",
     "html-webpack-plugin": "2.30.1",
     "identity-obj-proxy": "3.0.0",
     "jest": "26.1.0",

--- a/packages/divi-scripts/package.json
+++ b/packages/divi-scripts/package.json
@@ -49,7 +49,7 @@
     "grunt": "1.0.2",
     "grunt-contrib-compress": "1.6.0",
     "grunt-po2mo": "elegantthemes/grunt-po2mo#master",
-    "grunt-wp-i18n": "ayubadiputra/grunt-wp-i18n#testing",
+    "grunt-wp-i18n": "elegantthemes/grunt-wp-i18n#develop",
     "html-webpack-plugin": "2.30.1",
     "identity-obj-proxy": "3.0.0",
     "jest": "26.1.0",


### PR DESCRIPTION
# Summary

Fixes: [3PS :: Create Divi Extension :: Incompatible Grunt and Node Version](https://github.com/elegantthemes/Divi/issues/31229#top)

After checking the code, I found out that the issue comes from the `grunt-wp-i18n` package used by Divi Scripts [here](https://github.com/elegantthemes/create-divi-extension/blob/722ad2ece1241842ea9ebdaf8ff781be203f2f6e/packages/divi-scripts/package.json#L52). The grunt-wp-i18n [packages uses](https://github.com/cedaro/grunt-wp-i18n/blob/130e10b3603cb35bdc7b4b63d7e2d3462a030552/package.json#L23) "grunt": "^1.0.3" which means it will look greater minor versions. Meanwhile, the grunt v1.6.1 requires node v16 as minimum requirement. This is the reason why the error happens.

This approach is to fork `grunt-wp-i18n` package and modify the grunt version used there in [this commit](https://github.com/elegantthemes/grunt-wp-i18n/commit/f729e8128ed45eaae19d47e9406cc12de400ef14). Then, use that forked package in the Divi Scripts in [this commit](https://github.com/elegantthemes/create-divi-extension/pull/626/commits/d5fbf57f32561d581c610042e44325d5789faae8). This solution does solve the issue and Create Divi Extension works fine to create new extension and run the build.

There are pros and cons from this approach.
( - ) We need to fork the `grunt-wp-i18n` package, which means we need to ask ET GitHub administrator to fork that library and modify it later.
( + ) Easier approach and it works based on the test.
( + ) The last update for `grunt-wp-i18n` package based on [the last commit](https://github.com/cedaro/grunt-wp-i18n/commits/develop) was about 4 years ago. So, it seems the library won’t be updated in the future.

## Setup Testing Environment
1. Create a directory, for example: `test-cde`.
2. Inside that directory, clone `https://github.com/elegantthemes/create-divi-extension`.
3. Initialize yarn to create lock file and `node_modules` -> `yarn`.
4. Add `create-divi-extension` package we cloned earlier: `yarn add ./create-divi-extension/packages/create-divi-extension`.

https://user-images.githubusercontent.com/9313128/228727268-5d59a2e3-17a0-43da-87d1-d8adf121dffb.mp4

## Demo Grunt and Node Incompatible Error Before Fix (Master)
1. Go to create-divi-extension directory we cloned earlier.
2. Checkout `master` branch.
3. Back to root of `test-cde` directory.
4. Run `yarn create-divi-extension super-app --scripts-version file:create-divi-extension/packages/divi-scripts`.
5. When the process still running, you will notice the error later.

https://user-images.githubusercontent.com/9313128/228727455-87209545-a4a2-44fe-900b-bfe45ca9434b.mp4

## Demo CDE Works As Expected After Fix (`31229-update-grunt-wp-i18n-dep`)
1. Go to create-divi-extension directory we cloned earlier.
2. Checkout `31229-update-grunt-wp-i18n-dep` branch.
3. Back to root of `test-cde` directory.
4. Run `yarn create-divi-extension super-app --scripts-version file:create-divi-extension/packages/divi-scripts`.
5. Once the process done, you should see the Create Divi Extension prompts. Fill in the forms to finish the process.
6. You should see `super-app` directory now inside `test-cde` directory.
7. Go to `super-app` directory.
8. Run `yarn start` -> Should work as expected.
9. Run `yarn build` -> Should work as expected.
10. Run `yarn zip` -> Should generate super-app.zip package.

https://user-images.githubusercontent.com/9313128/228727966-2a446f0c-6fe6-4f1e-b759-a1ba8a1739e5.mp4

